### PR TITLE
Make the Static urlPrefix render as a cross-origin URL

### DIFF
--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -508,14 +508,18 @@ mkRequest opts request =
 
 mkUrl :: ElmOptions -> [F.Segment EType] -> Doc
 mkUrl opts segments =
-  "Url.Builder.absolute" <$>
-  (indent i . elmList)
+  urlBuilder <$>
+    (indent i . elmList)
     ( map segmentToDoc segments)
-    -- ( case urlPrefix opts of
-    --     Dynamic -> "urlBase"
-    --     Static url -> dquotes (stext url)
-    --   : map segmentToDoc segments)
+  -- ( case urlPrefix opts of
+  --     Dynamic -> "urlBase"
+  --     Static url -> dquotes (stext url)
+  --   : map segmentToDoc segments)
   where
+    urlBuilder :: Doc
+    urlBuilder = case urlPrefix opts of
+      Dynamic -> "Url.Builder.absolute" :: Doc
+      Static url -> "Url.Builder.crossOrigin" <+> dquotes (stext url)
 
     segmentToDoc :: F.Segment EType -> Doc
     segmentToDoc s =


### PR DESCRIPTION
Took the liberty to make slight improvement to your branch based on `elm-bridge`. In here I'm choosing a cross-origin URL builder for the cases in which the `urlPrefix` in the options is set to `Static`.

Probably a better approach would be to change the original ADT as:

```haskell
data UrlPrefix =
    NoPrefix
  | Relative String
  | CrossOrigin String
```

Which would map really well to the different options for Elm's `Url.Builder`. This change works for me so let me know what you think.